### PR TITLE
Bump dependencies: ncu -u

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,23 +15,25 @@
   "author": "Wilson Hobbs",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "7.2.2",
-    "@ionic/angular": "4.6.1",
+    "@angular/core": "8.2.14",
+    "@ionic/angular": "4.11.5",
     "@types/hammerjs": "^2.0.36",
     "hammerjs": "^2.0.8"
   },
   "devDependencies": {
-    "@angular/common": "7.2.2",
-    "@angular/compiler": "^7.2.2",
-    "@angular/compiler-cli": "7.2.2",
-    "@angular/core": "7.2.2",
-    "@ionic/angular": "4.6.1",
-    "awesome-typescript-loader": "^2.2.1",
-    "ng-packagr": "5.5.0",
-    "rxjs": "6.5.2",
-    "tsickle": "^0.37.0",
-    "typescript": "3.1.6",
-    "zone.js": "0.8.29"
+    "@angular/common": "8.2.14",
+    "@angular/compiler": "^8.2.14",
+    "@angular/compiler-cli": "8.2.14",
+    "@angular/core": "8.2.14",
+    "@ionic/angular": "4.11.5",
+    "@types/hammerjs": "^2.0.36",
+    "awesome-typescript-loader": "^5.2.1",
+    "hammerjs": "^2.0.8",
+    "ng-packagr": "5.7.1",
+    "rxjs": "6.5.3",
+    "tsickle": "^0.37.1",
+    "typescript": "3.5.3",
+    "zone.js": "0.10.2"
   },
   "ngPackage": {
     "lib": {


### PR DESCRIPTION
should fix #20 

- [x] add dev dependency:
  * @types/hammerjs
  * hammerjs
- [x] manually bump typescript to 3.5.3 (last supported by ng-packagr)
- [x] bump all other deps with ncu -u